### PR TITLE
Feature / authorization status check

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.h
@@ -19,7 +19,7 @@
 @property BOOL isSync;
 
 - (void)isHealthKitAvailable:(RCTResponseSenderBlock)callback;
-- (void)authorizationStatus:(NSArray *)permissionNames callback:(RCTResponseSenderBlock)callback;
+- (void)authorizationStatus:(NSArray *)permissionNames resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 - (void)initializeHealthKit:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)checkPermission:(NSString *)input callback:(RCTResponseSenderBlock)callback;
 - (void)getModuleInfo:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.h
@@ -19,7 +19,7 @@
 @property BOOL isSync;
 
 - (void)isHealthKitAvailable:(RCTResponseSenderBlock)callback;
-- (void)authorizationStatus:(RCTResponseSenderBlock)callback;
+- (void)authorizationStatus:(NSArray *)permissionNames callback:(RCTResponseSenderBlock)callback;
 - (void)initializeHealthKit:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)checkPermission:(NSString *)input callback:(RCTResponseSenderBlock)callback;
 - (void)getModuleInfo:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.h
@@ -19,6 +19,7 @@
 @property BOOL isSync;
 
 - (void)isHealthKitAvailable:(RCTResponseSenderBlock)callback;
+- (void)authorizationStatus:(RCTResponseSenderBlock)callback;
 - (void)initializeHealthKit:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)checkPermission:(NSString *)input callback:(RCTResponseSenderBlock)callback;
 - (void)getModuleInfo:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -231,6 +231,14 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
 }
 
 
+-(instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.healthStore = [[HKHealthStore alloc] init];
+    }
+}
+
 - (void)isHealthKitAvailable:(RCTResponseSenderBlock)callback
 {
     BOOL isAvailable = NO;
@@ -244,10 +252,6 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
 {
     if ([permissionNames count] == 0) {
         reject(@"no_permission_provided", @"[HealthKit][authorizationStatus] please provide permission names", [NSNull null]);
-    }
-    if (!self.healthStore) {
-        // When healthStore is not initialized, the function always returns UNKNOWN and we want to avoid that.
-        self.healthStore = [[HKHealthStore alloc] init];
     }
     
     NSSet *permissionObjects = [self getWritePermsFromOptions: permissionNames];
@@ -268,10 +272,6 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
 
 - (void)initializeHealthKit:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
-    if (!self.healthStore) {
-        self.healthStore = [[HKHealthStore alloc] init];
-    }
-
     if ([HKHealthStore isHealthDataAvailable]) {
         NSSet *writeDataTypes;
         NSSet *readDataTypes;

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -34,9 +34,9 @@ RCT_EXPORT_METHOD(isAvailable:(RCTResponseSenderBlock)callback)
     [self isHealthKitAvailable:callback];
 }
 
-RCT_EXPORT_METHOD(authStatus:(NSArray *)permissionNames callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(authStatus:(NSArray *)permissionNames resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [self authorizationStatus:permissionNames callback:callback];
+    [self authorizationStatus:permissionNames resolver:resolve rejecter:reject];
 }
 
 RCT_EXPORT_METHOD(initHealthKit:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
@@ -240,8 +240,12 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
     callback(@[[NSNull null], @(isAvailable)]);
 }
 
-- (void)authorizationStatus:(NSArray *)domains callback:(RCTResponseSenderBlock)callback
+- (void)authorizationStatus:(NSArray *)permissionNames resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject
 {
+    if ([permissionNames count] == 0) {
+        reject(@"no_permission_provided", @"[HealthKit][authorizationStatus] please provide permission names", [NSNull null]);
+    }
+    
     NSSet *permissionObjects = [self getWritePermsFromOptions: permissionNames];
     
     NSMutableArray *authStatuses = [[NSMutableArray alloc] init];
@@ -250,11 +254,11 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
     }
     
     if([authStatuses containsObject:@(HKAuthorizationStatusSharingDenied)]) {
-        callback(@[[NSNull null], @"DENIED"]);
+        resolve(@"DENIED");
     } else if ([authStatuses containsObject:@(HKAuthorizationStatusNotDetermined)]) {
-        callback(@[[NSNull null], @"UNKNOWN"]);
+        resolve(@"UNKNOWN");
     } else {
-        callback(@[[NSNull null], @"AUTHORIZED"]);
+        resolve(@"AUTHORIZED");
     }
 }
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -250,7 +250,6 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
         [domainObjects addObject:HKQuantityTypeIdentifierDietaryFiber];
     }
     if([domains containsObject:@"WEIGHT"]) {
-        callback(@[[NSNull null], domains]);
         [domainObjects addObject:HKQuantityTypeIdentifierBodyMass];
     }
     

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -245,6 +245,10 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
     if ([permissionNames count] == 0) {
         reject(@"no_permission_provided", @"[HealthKit][authorizationStatus] please provide permission names", [NSNull null]);
     }
+    if (!self.healthStore) {
+        // When healthStore is not initialized, the function always returns UNKNOWN and we want to avoid that.
+        self.healthStore = [[HKHealthStore alloc] init];
+    }
     
     NSSet *permissionObjects = [self getWritePermsFromOptions: permissionNames];
     
@@ -264,7 +268,9 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
 
 - (void)initializeHealthKit:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
-    self.healthStore = [[HKHealthStore alloc] init];
+    if (!self.healthStore) {
+        self.healthStore = [[HKHealthStore alloc] init];
+    }
 
     if ([HKHealthStore isHealthDataAvailable]) {
         NSSet *writeDataTypes;

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -34,9 +34,9 @@ RCT_EXPORT_METHOD(isAvailable:(RCTResponseSenderBlock)callback)
     [self isHealthKitAvailable:callback];
 }
 
-RCT_EXPORT_METHOD(authStatus:(NSArray *)domains callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(authStatus:(NSArray *)permissionNames callback:(RCTResponseSenderBlock)callback)
 {
-    [self authorizationStatus:domains callback:callback];
+    [self authorizationStatus:permissionNames callback:callback];
 }
 
 RCT_EXPORT_METHOD(initHealthKit:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -242,16 +242,7 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
 
 - (void)authorizationStatus:(NSArray *)domains callback:(RCTResponseSenderBlock)callback
 {
-    NSMutableArray *domainObjects = [[NSMutableArray alloc] init];
-    if([domains containsObject:@"WORKOUTS"]) {
-        [domainObjects addObject:[HKSampleType workoutType]];
-    }
-    if([domains containsObject:@"MEALS"]) {
-        [domainObjects addObject:HKQuantityTypeIdentifierDietaryFiber];
-    }
-    if([domains containsObject:@"WEIGHT"]) {
-        [domainObjects addObject:HKQuantityTypeIdentifierBodyMass];
-    }
+    NSSet *domainObjects = [self getWritePermsFromOptions: domains];
     
     NSMutableArray *authStatuses = [[NSMutableArray alloc] init];
     for(HKObjectType *domain in domainObjects) {

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -242,11 +242,11 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
 
 - (void)authorizationStatus:(NSArray *)domains callback:(RCTResponseSenderBlock)callback
 {
-    NSSet *domainObjects = [self getWritePermsFromOptions: domains];
+    NSSet *permissionObjects = [self getWritePermsFromOptions: permissionNames];
     
     NSMutableArray *authStatuses = [[NSMutableArray alloc] init];
-    for(HKObjectType *domain in domainObjects) {
-        [authStatuses addObject:@([self.healthStore authorizationStatusForType:domain])];
+    for(HKObjectType *permission in permissionObjects) {
+        [authStatuses addObject:@([self.healthStore authorizationStatusForType:permission])];
     }
     
     if([authStatuses containsObject:@(HKAuthorizationStatusSharingDenied)]) {


### PR DESCRIPTION
This PR is a part of https://github.com/8fit/mobile/issues/4286

Implemented this function from HealthKitBridge in our project. Only difference is that the one I've implemented accepts permissions as arguments, instead of domain group names. I think we should do the domain to permission mapping ourselves. 

```Swift
@objc func authorizationStatus(_ domains: [String]?,
                                   resolver: @escaping RCTPromiseResolveBlock,
                                   rejecter: @escaping RCTPromiseRejectBlock) {
        var samplesToCheck: [HKObjectType] = []

        if domains?.contains("WORKOUTS") == true {
            samplesToCheck.append(HKSampleType.workoutType())
        }

        if domains?.contains("MEALS") == true {
            samplesToCheck.append(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryFiber)!)
        }

        if domains?.contains("WEIGHT") == true {
            samplesToCheck.append(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!)
        }

        if samplesToCheck.isEmpty {
            rejecter("no_areas_specified", "you must provider areas to check", nil)
            return
        }

        let results = samplesToCheck.map { store.authorizationStatus(for: $0) }
        if results.contains(.sharingDenied) {
            resolver("DENIED")
        } else if results.contains(.notDetermined) {
            resolver("UNKNOWN")
        } else {
            resolver("AUTHORIZED")
        }
    }
```